### PR TITLE
🐛 Fix: Simpan Draft Bug - Button Simpan Draft malah submit tugas

### DIFF
--- a/backend/src/assignments/dto/create-submission.dto.ts
+++ b/backend/src/assignments/dto/create-submission.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString, IsNumber, Min } from 'class-validator';
+import { IsOptional, IsString, IsNumber, Min, IsEnum } from 'class-validator';
+import { SubmissionStatus } from '../../entities/submission.entity';
 
 export class CreateSubmissionDto {
   @IsOptional()
@@ -17,4 +18,8 @@ export class CreateSubmissionDto {
   @IsNumber({}, { message: 'Ukuran file harus berupa angka' })
   @Min(0, { message: 'Ukuran file tidak boleh negatif' })
   fileSize?: number;
+
+  @IsOptional()
+  @IsEnum(SubmissionStatus, { message: 'Status submission tidak valid' })
+  status?: SubmissionStatus;
 }


### PR DESCRIPTION
## 🐛 Bug Fix: Simpan Draft tidak berfungsi di Buat Tugas

### **Masalah yang Diperbaiki:**
- Button "Simpan Draft" di halaman submit assignment malah melakukan submit langsung
- User tidak bisa menyimpan draft tugas, semua langsung ter-submit

### **Root Cause Analysis:**
1. **Frontend** ✅ sudah benar - mengirim status DRAFT/SUBMITTED dengan benar
2. **Backend** ❌ ada bug:
   - `CreateSubmissionDto` tidak memiliki field `status`
   - Method `submitAssignment()` **hardcode** status ke `SUBMITTED` tanpa mempedulikan input

### **Perubahan yang Dibuat:**

#### **Backend Fixes:**
1. **Updated `CreateSubmissionDto`**
   - ➕ Menambahkan field `status` dengan validasi `@IsEnum(SubmissionStatus)`
   - ✅ Sekarang menerima status DRAFT/SUBMITTED dari frontend

2. **Fixed `submitAssignment()` method**
   - ❌ **BEFORE:** `status: SubmissionStatus.SUBMITTED` (hardcode)
   - ✅ **AFTER:** `status: createSubmissionDto.status || SubmissionStatus.DRAFT`
   - ✅ Default ke DRAFT jika status tidak diberikan
   - ✅ Hanya set `submittedAt` untuk actual submissions, bukan drafts
   - ✅ Validasi late submission hanya untuk actual submissions
   - ✅ Check duplicate submission hanya saat submit, bukan draft

#### **Logic Flow Sekarang:**
```typescript
// Draft: status = DRAFT, submittedAt = null
// Submit: status = SUBMITTED, submittedAt = now
```

### **Testing yang Diperlukan:**
- [ ] Test "Simpan Draft" - harus save tanpa submit
- [ ] Test "Kirim Tugas" - harus actual submit
- [ ] Test edit draft lalu submit
- [ ] Test late submission validation

### **Impact:**
- ✅ User bisa save draft tanpa submit
- ✅ Draft bisa diedit dan submit nanti  
- ✅ No breaking changes untuk existing functionality