### PR TITLE
Fix TypeScript onClick handler type mismatch in InteractivePostCard

### DIFF
--- a/frontend/src/components/ui/InteractivePostCard.tsx
+++ b/frontend/src/components/ui/InteractivePostCard.tsx
@@ -27,7 +27,7 @@ interface InteractivePostCardProps {
   onQuickReact: (postId: string, reactionType: string) => void;
   onBookmark: (postId: string) => void;
   onShare?: (postId: string) => void;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
   showReactionBar?: boolean;
   className?: string;
 }
@@ -102,7 +102,7 @@ const InteractivePostCard: React.FC<InteractivePostCardProps> = ({
     }
     
     if (onClick) {
-      onClick();
+      onClick(e);
     } else {
       navigate(`/forums/${post.id}`);
     }


### PR DESCRIPTION
## **TypeScript Build Fix**

### **Problem**
Docker build was failing with TypeScript compilation error:
```
TS2322: Type '(e: React.MouseEvent) => void' is not assignable to type '() => void'.
```

### **Root Cause**
The `onClick` prop in `InteractivePostCard.tsx` was defined as `() => void` but the actual handler `handleCardClick` expected a `React.MouseEvent` parameter.

### **Solution**
- Updated the `onClick` prop interface to accept `(e: React.MouseEvent) => void`
- This maintains type safety while resolving the compilation error
- No breaking changes to existing functionality

### **Testing**
- TypeScript compilation should now pass
- Docker build should complete successfully
- Component behavior remains unchanged

### **Files Changed**
- `frontend/src/components/ui/InteractivePostCard.tsx`

### **Impact**
- ✅ Fixes Docker build failure
- ✅ Maintains existing functionality
- ✅ Improves type safety
- ✅ No breaking changes